### PR TITLE
Service Provisioning using IP Address

### DIFF
--- a/centoswebpanel.php
+++ b/centoswebpanel.php
@@ -325,7 +325,7 @@ class Centoswebpanel extends Module
      */
     public function addModuleRow(array &$vars)
     {
-        $meta_fields = ['server_name', 'host_name', 'login_port', 'port', 'api_key',
+        $meta_fields = ['server_name', 'host_name', 'ip', 'login_port', 'port', 'api_key',
             'use_ssl', 'account_limit', 'name_servers', 'notes'];
         $encrypted_fields = ['api_key'];
 
@@ -368,7 +368,7 @@ class Centoswebpanel extends Module
      */
     public function editModuleRow($module_row, array &$vars)
     {
-        $meta_fields = ['server_name', 'host_name', 'login_port', 'port', 'api_key',
+        $meta_fields = ['server_name', 'host_name', 'ip', 'login_port', 'port', 'api_key',
             'use_ssl', 'account_limit', 'account_count', 'name_servers', 'notes'];
         $encrypted_fields = ['api_key'];
 
@@ -700,7 +700,7 @@ class Centoswebpanel extends Module
         }
 
         $params = $this->getFieldsFromInput((array) $vars, $package);
-        $params['server_ips'] = $row->meta->host_name;
+        $params['server_ips'] = $row->meta->ip;
 
         $this->validateService($package, $vars);
 
@@ -779,7 +779,7 @@ class Centoswebpanel extends Module
 
         $params = $this->getFieldsFromInput((array) $vars, $package, true);
         $service_fields = $this->serviceFieldsToObject($service->fields);
-        $params['server_ips'] = $row->meta->host_name;
+        $params['server_ips'] = $row->meta->ip;
 
         // Default fields using service fields
         if (!isset($params['domain'])) {
@@ -1124,6 +1124,18 @@ class Centoswebpanel extends Module
     }
 
     /**
+     * Validates that the given IP Address is valid.
+     *
+     * @param string $ip The IP to validate
+     * @return bool True if the IP is valid, false otherwise
+     */
+    public function validateIP($ip)
+    {
+        $validator = new Server();
+        return $validator->isIp($ip);
+    }
+
+    /**
      * Validates that at least 2 name servers are set in the given array of name servers.
      *
      * @param array $name_servers An array of name servers
@@ -1386,6 +1398,12 @@ class Centoswebpanel extends Module
                     'message' => Language::_('Centoswebpanel.!error.host_name_valid', true)
                 ]
             ],
+            'ip' => [
+                'valid' => [
+                    'rule' => [[$this, 'validateIP']],
+                    'message' => Language::_('Centoswebpanel.!error.ip_valid', true)
+                ]
+            ],            
             'login_port' => [
                 'valid' => [
                     'rule' => 'isEmpty',

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.6.0",
+    "version": "2.6.1",
     "name": "Centoswebpanel.name",
     "description": "Centoswebpanel.description",
     "authors": [

--- a/language/en_us/centoswebpanel.php
+++ b/language/en_us/centoswebpanel.php
@@ -16,6 +16,7 @@ $lang['Centoswebpanel.manage.module_rows_title'] = 'Servers';
 $lang['Centoswebpanel.manage.module_groups_title'] = 'Server Groups';
 $lang['Centoswebpanel.manage.module_rows_heading.name'] = 'Server Label';
 $lang['Centoswebpanel.manage.module_rows_heading.hostname'] = 'Hostname';
+$lang['Centoswebpanel.manage.module_rows_heading.ip'] = 'IP Address';
 $lang['Centoswebpanel.manage.module_rows_heading.accounts'] = 'Accounts';
 $lang['Centoswebpanel.manage.module_rows_heading.options'] = 'Options';
 $lang['Centoswebpanel.manage.module_groups_heading.name'] = 'Group Name';
@@ -59,6 +60,7 @@ $lang['Centoswebpanel.edit_row.add_btn'] = 'Edit Server';
 
 $lang['Centoswebpanel.row_meta.server_name'] = 'Server Label';
 $lang['Centoswebpanel.row_meta.host_name'] = 'Hostname';
+$lang['Centoswebpanel.row_meta.ip'] = 'IP Address';
 $lang['Centoswebpanel.row_meta.login_port'] = 'Login Port';
 $lang['Centoswebpanel.row_meta.default_login_port'] = '2031';
 $lang['Centoswebpanel.row_meta.port'] = 'API Port';
@@ -94,6 +96,7 @@ $lang['Centoswebpanel.service_field.tooltip.password'] = 'You may leave the pass
 // Errors
 $lang['Centoswebpanel.!error.server_name_valid'] = 'You must enter a Server Label.';
 $lang['Centoswebpanel.!error.host_name_valid'] = 'The Hostname appears to be invalid.';
+$lang['Centoswebpanel.!error.ip_valid'] = 'The IP Address appears to be invalid.';
 $lang['Centoswebpanel.!error.user_name_valid'] = 'The User Name appears to be invalid.';
 $lang['Centoswebpanel.!error.login_port_valid'] = 'You must enter a login port.';
 $lang['Centoswebpanel.!error.port_valid'] = 'You must enter an API port.';

--- a/views/default/add_row.pdt
+++ b/views/default/add_row.pdt
@@ -27,6 +27,12 @@
                     </li>
                     <li>
                         <?php
+                        $this->Form->label($this->_('Centoswebpanel.row_meta.ip', true), 'ip');
+                        $this->Form->fieldText('host_name', (isset($vars->ip) ? $vars->ip : null));
+                        ?>
+                    </li>
+                    <li>
+                        <?php
                         $this->Form->label($this->_('Centoswebpanel.row_meta.login_port', true), 'login_port');
                         $this->Form->fieldText('login_port', (isset($vars->login_port) ? $vars->login_port : $this->_('Centoswebpanel.row_meta.default_login_port', true)));
                         ?>

--- a/views/default/edit_row.pdt
+++ b/views/default/edit_row.pdt
@@ -27,6 +27,12 @@
                     </li>
                     <li>
                         <?php
+                        $this->Form->label($this->_('Centoswebpanel.row_meta.ip', true), 'ip');
+                        $this->Form->fieldText('ip', (isset($vars->ip) ? $vars->ip : null));
+                        ?>
+                    </li>
+                    <li>
+                        <?php
                         $this->Form->label($this->_('Centoswebpanel.row_meta.login_port', true), 'login_port');
                         $this->Form->fieldText('login_port', (isset($vars->login_port) ? $vars->login_port : $this->_('Centoswebpanel.row_meta.default_login_port', true)));
                         ?>

--- a/views/default/manage.pdt
+++ b/views/default/manage.pdt
@@ -21,6 +21,7 @@
             <tr class="heading_row">
                 <td><span><?php $this->_('Centoswebpanel.manage.module_rows_heading.name'); ?></span></td>
                 <td><span><?php $this->_('Centoswebpanel.manage.module_rows_heading.hostname'); ?></span></td>
+                <td><span><?php $this->_('Centoswebpanel.manage.module_rows_heading.ip'); ?></span></td>
                 <td><span><?php $this->_('Centoswebpanel.manage.module_rows_heading.accounts'); ?></span></td>
                 <td class="last"><span><?php $this->_('Centoswebpanel.manage.module_rows_heading.options'); ?></span></td>
             </tr>
@@ -30,6 +31,7 @@
             <tr<?php echo ($i % 2 == 1) ? ' class="odd_row"' : ''; ?>>
                 <td><?php echo (isset($module->rows[$i]->meta->server_name) ? $this->Html->safe($module->rows[$i]->meta->server_name) : null); ?></td>
                 <td><?php echo (isset($module->rows[$i]->meta->host_name) ? $this->Html->safe($module->rows[$i]->meta->host_name) : null); ?></td>
+                <td><?php echo (isset($module->rows[$i]->meta->ip) ? $this->Html->safe($module->rows[$i]->meta->ip) : null); ?></td>
                 <td><?php $this->_('Centoswebpanel.manage.module_rows.count', false, (isset($module->rows[$i]->meta->account_count) ? $module->rows[$i]->meta->account_count : 0), ((isset($module->rows[$i]->meta->account_limit) ? $module->rows[$i]->meta->account_limit : null) == '' ? '∞' : $module->rows[$i]->meta->account_limit)); ?></td>
                 <td class="last">
                     <a href="<?php echo $this->Html->safe($this->base_uri . 'settings/company/modules/editrow/' . (isset($module->id) ? $module->id : null) . '/' . (isset($module->rows[$i]->id) ? $module->rows[$i]->id : null) . '/'); ?>"><?php $this->_('Centoswebpanel.manage.module_rows.edit'); ?></a>


### PR DESCRIPTION
Added a server field for a IP Address and then validate the IP and present a warning if not a valid IP. Updated the module to use the IP Address instead of hostname for the server_ips value when provisioning a service. Updated version to 2.6.1.